### PR TITLE
Bugfix: Robust Database URL-s

### DIFF
--- a/resource_allocator/config.py
+++ b/resource_allocator/config.py
@@ -1,9 +1,12 @@
 import os
 
-URL = "postgresql://{user}:{password}@{server}:{port}/{database}".format(
-    user = os.environ["USER"],
+from sqlalchemy.engine import url
+
+URL = url.URL(
+    drivername = "postgresql",
+    username = os.environ["USER"],
     password = os.environ["PASSWORD"],
-    server = os.environ["SERVER"],
+    host = os.environ["SERVER"],
     port = os.environ["PORT"],
     database = os.environ["DATABASE"],
 )


### PR DESCRIPTION
Changed config to use sqlalchemy.engine.url.URL in order to handle odd connection parameters