### PR TITLE
Bugfix: Allocation Should Allow Multiple Top Resource Groups

### DIFF
--- a/alembic/versions/9627bdb6499f_misc_alembic_fixes.py
+++ b/alembic/versions/9627bdb6499f_misc_alembic_fixes.py
@@ -36,7 +36,7 @@ def upgrade() -> None:
     op.alter_column(
             'allocation', 'points',
             existing_type=sa.INTEGER(),
-            nullable=False,
+            nullable=True,
             schema='resource_allocator')
     op.alter_column(
             'image_properties', 'box_x',

--- a/resource_allocator/managers/request.py
+++ b/resource_allocator/managers/request.py
@@ -20,4 +20,4 @@ class RequestManager(BaseManager):
             )
             data["request_status_id"] = cls.sess.execute(query).scalar()
 
-        super().create_item(data)
+        return super().create_item(data)

--- a/resource_allocator/managers/resource.py
+++ b/resource_allocator/managers/resource.py
@@ -3,7 +3,9 @@ Managers for working with resources
 """
 
 from resource_allocator.models import (
-    ResourceModel, ResourceGroupModel, ResourceToGroupModel,
+    ResourceModel,
+    ResourceGroupModel,
+    ResourceToGroupModel,
 )
 
 from resource_allocator.managers.base import BaseManager
@@ -27,6 +29,17 @@ class ResourceGroupManager(BaseManager):
         "image": ImageManager,
         "image_properties": ImagePropertiesManager,
     }
+
+    @classmethod
+    def create_item(cls, data: dict) -> ResourceGroupModel:
+        result = super().create_item(data)
+        if not data["is_top_level"]:
+            return result
+
+        sess = cls.sess
+        result.top_resource_group_id = result.id
+        sess.flush()
+        return result
 
 
 class ResourceToResourceGroupManager(BaseManager):

--- a/resource_allocator/models.py
+++ b/resource_allocator/models.py
@@ -9,6 +9,7 @@ import sqlalchemy as db
 from sqlalchemy import (
     ForeignKey,
     func,
+    inspect,
 )
 from sqlalchemy import orm
 from sqlalchemy.orm import (
@@ -16,6 +17,7 @@ from sqlalchemy.orm import (
     relationship,
     Mapped,
     mapped_column,
+    ColumnProperty,
 )
 
 
@@ -30,6 +32,19 @@ class Base(DeclarativeBase):
         server_default=func.now(),
         onupdate=func.now(),
     )
+
+    def __repr__(self):
+        mapper = inspect(self.__class__)
+        cols = {
+            f"{key}={self.__dict__.get(key) if isinstance(value, ColumnProperty) else '...'}"
+            for key, value
+            in mapper.attrs.items()
+        }
+        return (
+            f"{self.__class__.__name__}("
+            f"{', '.join(cols)}"
+            ")"
+        )
 
 
 class RoleEnum(Enum):
@@ -125,6 +140,7 @@ class RequestModel(Base):
         ForeignKey("request_status.id", name="request_request_status_id_fkey"),
     )
     request_status: Mapped["RequestStatusModel"] = relationship()
+    allocation: Mapped["AllocationModel"] = relationship()
 
 
 class AllocationModel(Base):

--- a/resource_allocator/models.py
+++ b/resource_allocator/models.py
@@ -151,7 +151,8 @@ class AllocationModel(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
     source_request_id: Mapped[int] = mapped_column(ForeignKey("request.id"))
     allocated_resource_id: Mapped[int | None] = mapped_column(ForeignKey("resource.id"))
-    points: Mapped[int]
+    allocated_resource: Mapped[ResourceModel | None] = relationship()
+    points: Mapped[int | None]
 
 
 class ImageTypeModel(Base):

--- a/resource_allocator/resources/base.py
+++ b/resource_allocator/resources/base.py
@@ -134,5 +134,5 @@ class BaseResource(ABC, Resource):
         if errors:
             return abort(400, f"Data validation errors: {errors}")
 
-        result = self.manager.modify_item(id, self.request_schema().dump(combined))
+        result = self.manager.modify_item(id, self.request_schema().load(combined))
         return self.response_schema().dump(result)

--- a/resource_allocator/schemas/request.py
+++ b/resource_allocator/schemas/request.py
@@ -28,6 +28,7 @@ class RequestRequestSchema(Schema):
     user_id = fields.Integer(required=True)
     requested_resource_id = fields.Integer(allow_none=True)
     requested_resource_group_id = fields.Integer(allow_none=True)
+    id = fields.Integer()
 
     @validates("iteration_id")
     def validate_iteration_id(self, value):
@@ -97,7 +98,8 @@ class RequestRequestSchema(Schema):
                 or_(
                     ResourceModel.top_resource_group_id == top_group.id,
                     ResourceGroupModel.top_resource_group_id == top_group.id,
-                )
+                ),
+                RequestModel.id != data.get("id")
             )
         )
         if sess.scalars(query).first():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,12 +2,13 @@
 Models test case
 """
 
+import datetime as dt
 import unittest
 
 from sqlalchemy import create_engine, select, text
 from sqlalchemy.orm import Session
 
-from resource_allocator.models import Base, UserModel
+from resource_allocator.models import Base, UserModel, IterationModel
 
 
 class ModelsTestCase(unittest.TestCase):
@@ -18,9 +19,22 @@ class ModelsTestCase(unittest.TestCase):
             con.execute(text("attach database \":memory:\" as resource_allocator_test"))
             con.commit()
 
-    def test_create_all(self):
         Base.metadata.create_all(self.engine)
+
+    def test_create_all(self):
         with Session(self.engine) as sess:
             data = sess.scalars(select(UserModel)).all()
 
         self.assertEqual(data, [])
+
+    def test_repr(self):
+        Base.metadata.create_all(self.engine)
+        with Session(self.engine) as sess:
+            item = IterationModel(start_date=dt.date(2025, 1, 1), end_date=dt.date(2025, 1, 15))
+            sess.add(item)
+            sess.flush()
+
+        result = str(item)
+        self.assertIn("IterationModel(", result)
+        self.assertIn("id=1", result)
+        self.assertIn("requests=...", result)


### PR DESCRIPTION
- Added AllocationManager.create_item overwrite to modify request status upon allocation
- Changed schema validation to allow updates to request and allocation
- Allow creating allocations for the same user in a different top resource group in schemas.allocation
- Added AllocationManager methods _asign_points and _remove_requests
- Modified automatic allocation to allow the same user to receive resources in different top resource groups
- Added models.Base.__repr__ method